### PR TITLE
Make secure cookie option explicit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,6 +51,7 @@ var CONFIG = {
   overwrite: true, /** (boolean) can overwrite or not (default true) */
   httpOnly: true, /** (boolean) httpOnly or not (default true) */
   signed: true, /** (boolean) signed or not (default true) */
+  secure: false, /** (boolean) secure or not (default false) */
 };
 app.use(session(CONFIG, app));
 // or if you prefer all default config, just use => app.use(session(app));

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = function(opts, app){
   if (null == opts.overwrite) opts.overwrite = true;
   if (null == opts.httpOnly) opts.httpOnly = true;
   if (null == opts.signed) opts.signed = true;
+  if (null == opts.secure) opts.secure = false;
 
   debug('session options %j', opts);
 


### PR DESCRIPTION
I found it opaque when I wanted to make my session cookie secure. I think it would work as-is, but making it more explicit would keep people like me from needing to delve into the internals of the library.