### PR TITLE
Support ctx.respond = false

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -192,6 +192,11 @@ class ContextSession {
     const opts = this.opts;
     const ctx = this.ctx;
 
+    if (ctx.headerSent) {
+      debug('skipping commit due to ctx.headersSent');
+      return;
+    }
+
     // not accessed
     if (undefined === session) return;
 

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -606,6 +606,32 @@ describe('Koa Session External Context Store', () => {
     });
   });
 
+  describe('when headers are sent', () => {
+    it('should not commit', done => {
+      const app = App();
+      let appError;
+      app.on('error', err => {
+        appError = err;
+      });
+
+      app.use(async function(ctx) {
+        ctx.respond = false;
+        ctx.response.status = 200;
+        ctx.session.makeChange = true;
+
+        ctx.response.flushHeaders();
+        ctx.res.end();
+      });
+
+      request(app.listen())
+      .get('/')
+      .expect(200, err => {
+        done(err || appError);
+      });
+    });
+  });
+
+
   describe('ctx.session', () => {
     after(mm.restore);
 


### PR DESCRIPTION
Hi. First of all, thanks for koa. We did a very successful refactor from express to koa and our codebase is much slimmer, faster and easier to read.

Anyway, we have a very specific cache solution where we actually need to use the ctx.respond = false. I know it's unsupported and I understand why but we still want to use it in a very specific situation. I've managed to call the commit() command by getting the symbol from context but it tries another commit later in the codebase and there it emits an "Can't set headers after they are sent"

My solution to this would be to check for headerSent in commit to avoid this.

I know i'm in deep blue with features that are unsupported but this is the best way i could think of