### PR TITLE
replace unsafe new Buffer() by Buffer.alloc() when decode and encode

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -113,7 +113,7 @@ class ContextSession {
     } catch (err) {
       // backwards compatibility:
       // create a new session if parsing fails.
-      // new Buffer(string, 'base64') does not seem to crash
+      // `Buffer.alloc(size, string, 'base64')` does not seem to crash
       // when `string` is not base64-encoded.
       // but `JSON.parse(string)` will crash.
       debug('decode %j error: %s', cookie, err);

--- a/lib/context.js
+++ b/lib/context.js
@@ -113,7 +113,7 @@ class ContextSession {
     } catch (err) {
       // backwards compatibility:
       // create a new session if parsing fails.
-      // `Buffer.alloc(size, string, 'base64')` does not seem to crash
+      // Buffer.alloc(size, string, 'base64') does not seem to crash
       // when `string` is not base64-encoded.
       // but `JSON.parse(string)` will crash.
       debug('decode %j error: %s', cookie, err);

--- a/lib/session.js
+++ b/lib/session.js
@@ -55,7 +55,7 @@ class Session {
   }
 
   /**
-   * Return how many values there are in the session object.
+   * Return how many keys there are in the session object.
    * Used to see if it's "populated".
    *
    * @return {Number}

--- a/lib/util.js
+++ b/lib/util.js
@@ -13,7 +13,7 @@ module.exports = {
    */
 
   decode(string) {
-    const body = new Buffer(string, 'base64').toString('utf8');
+    const body = Buffer.alloc(Buffer.byteLength(string, 'base64'), string, 'base64').toString('utf8');
     const json = JSON.parse(body);
     return json;
   },
@@ -28,7 +28,7 @@ module.exports = {
 
   encode(body) {
     body = JSON.stringify(body);
-    return new Buffer(body).toString('base64');
+    return Buffer.alloc(Buffer.byteLength(body), body).toString('base64');
   },
 
   hash(sess) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "crc": "^3.4.4",
-    "debug": "^2.2.0",
+    "debug": "^2.6.9",
     "is-type-of": "^1.0.0",
     "uid-safe": "^2.1.3"
   },


### PR DESCRIPTION
1. session is sensitive data. `new Buffer()` was deprecated and unsafe(expose the session to public buffer memory). `Buffer.alloc` will never use buffer_pools, a little slower but safe.
2. add test: when session contains multibyte character should still work.
3. update debug to ^2.6.9, [fix: remove ReDoS regexp](https://github.com/visionmedia/debug/pull/504)
  