### PR TITLE
Fixes a bug that reset the cookie expire date to the default (1 day) when using browser sessions (maxAge: 'session')

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -291,6 +291,7 @@ class ContextSession {
       // do not set _expire in json if maxAge is set to 'session'
       // also delete maxAge from options
       opts.maxAge = undefined;
+      json._session = true;
     } else {
       // set expire for check
       json._expire = maxAge + Date.now();

--- a/lib/session.js
+++ b/lib/session.js
@@ -20,6 +20,7 @@ class Session {
       for (const k in obj) {
         // restore maxAge from store
         if (k === '_maxAge') this._ctx.sessionOptions.maxAge = obj._maxAge;
+        else if (k === '_session') this._ctx.sessionOptions.maxAge = 'session';
         else this[k] = obj[k];
       }
     }


### PR DESCRIPTION
**The problem**
When using browser sessions (setting `maxAge: 'session'`), after some session changes, the session cookie is set to expire using the default maxAge (1 day)

**Steps to Reproduce**
```js
const session = require('koa-session');
const Koa = require('koa');
const app = new Koa();

app.keys = ['some secret hurr'];

app.use(session({key: 'koa:sess', maxAge: 'session'}, app));

app.use(ctx => {
  // ignore favicon
  if (ctx.path === '/favicon.ico') return;

  let n = ctx.session.views || 0;
  ctx.session.views = ++n;
  ctx.body = n + ' views\n';
});

app.listen(3000);
console.log('listening on port 3000');
```

Run the code and navigate to http://localhost:3000, reload the page at least 3 times. The cookie will have an expire date (`expires=`):

```bash
$ curl -s -D - --cookie-jar cookies.txt --cookie cookies.txt localhost:3000
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Content-Length: 8
Set-Cookie: koa:sess=eyJ2aWV3cyI6MX0=; path=/; httponly
Set-Cookie: koa:sess.sig=GkHNXUBrhcvbQSvMwIu9qfvgmJk; path=/; httponly
Date: Fri, 20 Apr 2018 12:29:26 GMT
Connection: keep-alive

1 views
$ curl -s -D - --cookie-jar cookies.txt --cookie cookies.txt localhost:3000
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Content-Length: 8
Set-Cookie: koa:sess=eyJ2aWV3cyI6MiwiX2V4cGlyZSI6MTUyNDMxMzc3MDUxOSwiX21heEFnZSI6ODY0MDAwMDB9; path=/; httponly
Set-Cookie: koa:sess.sig=i3_GySh5tvSkIPMAGdNgMUyTRKE; path=/; httponly
Date: Fri, 20 Apr 2018 12:29:30 GMT
Connection: keep-alive

2 views
$ curl -s -D - --cookie-jar cookies.txt --cookie cookies.txt localhost:3000
HTTP/1.1 200 OK
Content-Type: text/plain; charset=utf-8
Content-Length: 8
Set-Cookie: koa:sess=eyJ2aWV3cyI6MywiX2V4cGlyZSI6MTUyNDMxMzc3MTcyMywiX21heEFnZSI6ODY0MDAwMDB9; path=/; expires=Sat, 21 Apr 2018 12:29:31 GMT; httponly
Set-Cookie: koa:sess.sig=MYVJ7UDEorfknpBTgWZOFazrYtY; path=/; expires=Sat, 21 Apr 2018 12:29:31 GMT; httponly
Date: Fri, 20 Apr 2018 12:29:31 GMT
Connection: keep-alive

3 views
```

**The solution**
Added the property `_session = true` to the session json when using browser sessions. That way the context can know that it is a browser sessions when recreating the session.

Added a new test case that changes a sessions 3 times and checks for cookie `expires=` when using browser sessions.