### PR TITLE
Fix session not works

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -15,8 +15,7 @@ class ContextSession {
   constructor(ctx, opts) {
     this.ctx = ctx;
     this.app = ctx.app;
-    // this.opts = Object.assign({}, opts);
-    this.opts = opts || {};
+    this.opts = Object.assign({}, opts);
     this.store = this.opts.ContextStore ? new this.opts.ContextStore(ctx) : this.opts.store;
   }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -15,6 +15,7 @@ class ContextSession {
   constructor(ctx, opts) {
     this.ctx = ctx;
     this.app = ctx.app;
+    // this.opts = Object.assign({}, opts);
     this.opts = opts || {};
     this.store = this.opts.ContextStore ? new this.opts.ContextStore(ctx) : this.opts.store;
   }


### PR DESCRIPTION
fix this issue: https://github.com/koajs/session/issues/133 

If the maxAge set to 'session', In first time visiting, `opts.maxAge` is change to `undefined` ( see https://github.com/koajs/session/blob/master/lib/context.js#L293 ) .

And the second time visiting `opts.maxAge` will be changed to `86400000` because https://github.com/koajs/session/blob/master/lib/context.js#L298  and
https://github.com/koajs/session/blob/master/lib/session.js#L22 ) 

Then I close the browser and visit again, the session not works because `opts.maxAge` has changed to `86400000`.

So it needs to assign a new opts object in every time the ContextSession is created.