### PR TITLE
Add autoCommit option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -151,7 +151,7 @@ if (this.session.isNew) {
 
   Save this session no matter whether it is populated.
 
-### Session#commitNow()
+### Session#manuallyCommit()
 
   Session headers are auto committed by default. Use this if `autoCommit` is set to `false`.
 

--- a/Readme.md
+++ b/Readme.md
@@ -151,6 +151,10 @@ if (this.session.isNew) {
 
   Save this session no matter whether it is populated.
 
+### Session#commitNow()
+
+  Session headers are auto committed by default. Use this if `autoCommit` is set to `false`.
+
 ### Destroying a session
 
   To destroy a session simply set it to `null`:

--- a/Readme.md
+++ b/Readme.md
@@ -53,6 +53,7 @@ const CONFIG = {
   /** 'session' will result in a cookie that expires when session/browser is closed */
   /** Warning: If a session cookie is stolen, this cookie will never expire */
   maxAge: 86400000,
+  autoCommit: true, /** (boolean) automatically commit headers (default true) */
   overwrite: true, /** (boolean) can overwrite or not (default true) */
   httpOnly: true, /** (boolean) httpOnly or not (default true) */
   signed: true, /** (boolean) signed or not (default true) */

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ function extendContext(context, opts) {
       },
     },
     session: {
-      commit() {
+      commitNow() {
         this[CONTEXT_SESSION].commit();
       },
       get() {

--- a/index.js
+++ b/index.js
@@ -124,7 +124,9 @@ function extendContext(context, opts) {
     },
     session: {
       commitNow() {
-        return this[CONTEXT_SESSION].commit();
+        if (!opts.autoCommit) {
+          return this[CONTEXT_SESSION].commit();
+        }
       },
       get() {
         return this[CONTEXT_SESSION].get();

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ function extendContext(context, opts) {
       },
     },
     session: {
-      commitNow() {
+      manuallyCommit() {
         if (!opts.autoCommit) {
           return this[CONTEXT_SESSION].commit();
         }

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function extendContext(context, opts) {
     },
     session: {
       commitNow() {
-        this[CONTEXT_SESSION].commit();
+        return this[CONTEXT_SESSION].commit();
       },
       get() {
         return this[CONTEXT_SESSION].get();

--- a/index.js
+++ b/index.js
@@ -42,7 +42,9 @@ module.exports = function(opts, app) {
     } catch (err) {
       throw err;
     } finally {
-      await sess.commit();
+      if (opts.autoCommit) {
+        await sess.commit();
+      }
     }
   };
 };
@@ -67,6 +69,7 @@ function formatOpts(opts) {
   if (opts.overwrite == null) opts.overwrite = true;
   if (opts.httpOnly == null) opts.httpOnly = true;
   if (opts.signed == null) opts.signed = true;
+  if (opts.autoCommit == null) opts.autoCommit = true;
 
   debug('session options %j', opts);
 
@@ -120,6 +123,9 @@ function extendContext(context, opts) {
       },
     },
     session: {
+      commit() {
+        this[CONTEXT_SESSION].commit()
+      },
       get() {
         return this[CONTEXT_SESSION].get();
       },

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function extendContext(context, opts) {
     },
     session: {
       commit() {
-        this[CONTEXT_SESSION].commit()
+        this[CONTEXT_SESSION].commit();
       },
       get() {
         return this[CONTEXT_SESSION].get();

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -397,7 +397,7 @@ describe('Koa Session External Context Store', () => {
         .post('/')
         .expect('Set-Cookie', /koa:sess=.+;/)
         .expect('hi')
-        .end((err, res) => {
+        .end(err => {
           if (err) return done(err);
         })
         .expect(200, done);

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -386,8 +386,8 @@ describe('Koa Session External Context Store', () => {
         app.use(async function(ctx) {
           if (ctx.method === 'POST') {
             ctx.session.message = 'hi';
-            await ctx.session.commitNow();
             ctx.body = 200;
+            await ctx.session.commitNow();
             return;
           }
           ctx.body = ctx.session.message;

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -356,6 +356,32 @@ describe('Koa Session External Context Store', () => {
     });
   });
 
+  describe('when autoCommit is present', () => {
+    describe('and set to false', () => {
+      it('should not set headers if commit() isn\'t called', done => {
+        const app = App({ autoCommit: false });
+        app.use(async function(ctx) {
+          if (ctx.method === 'POST') {
+            ctx.session.message = 'hi';
+            ctx.body = 200;
+            return;
+          }
+          ctx.body = ctx.session.message;
+        });
+        const server = app.listen();
+
+        request(server)
+        .post('/')
+        .end((err, res) => {
+          if (err) return done(err);
+          const cookie = res.headers['set-cookie'];
+          should.not.exists(cookie);
+        })
+        .expect(200, done);
+      });
+    });
+  });
+
   describe('when maxAge present', () => {
     describe('and set to be a session cookie', () => {
       it('should not expire the session', done => {

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -356,29 +356,27 @@ describe('Koa Session External Context Store', () => {
     });
   });
 
-  describe('when autoCommit is present', () => {
-    describe('and set to false', () => {
-      it('should not set headers if commit() isn\'t called', done => {
-        const app = App({ autoCommit: false });
-        app.use(async function(ctx) {
-          if (ctx.method === 'POST') {
-            ctx.session.message = 'hi';
-            ctx.body = 200;
-            return;
-          }
-          ctx.body = ctx.session.message;
-        });
-        const server = app.listen();
-
-        request(server)
-        .post('/')
-        .end((err, res) => {
-          if (err) return done(err);
-          const cookie = res.headers['set-cookie'];
-          should.not.exists(cookie);
-        })
-        .expect(200, done);
+  describe('when autoCommit is present and set to false', () => {
+    it('should not set headers if commit() isn\'t called', done => {
+      const app = App({ autoCommit: false });
+      app.use(async function(ctx) {
+        if (ctx.method === 'POST') {
+          ctx.session.message = 'hi';
+          ctx.body = 200;
+          return;
+        }
+        ctx.body = ctx.session.message;
       });
+      const server = app.listen();
+
+      request(server)
+      .post('/')
+      .end((err, res) => {
+        if (err) return done(err);
+        const cookie = res.headers['set-cookie'];
+        should.not.exists(cookie);
+      })
+      .expect(200, done);
     });
   });
 

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -387,17 +387,15 @@ describe('Koa Session External Context Store', () => {
           if (ctx.method === 'POST') {
             ctx.session.message = 'dummy';
             ctx.body = 200;
-            return;
           }
         });
         app.use(async function(ctx) {
-          await ctx.session.commitNow();
+          await ctx.session.manuallyCommit();
         });
         const server = app.listen();
 
         request(server)
         .post('/')
-        .expect('200')
         .end(err => {
           if (err) return done(err);
         })

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -386,7 +386,7 @@ describe('Koa Session External Context Store', () => {
         app.use(async function(ctx) {
           if (ctx.method === 'POST') {
             ctx.session.message = 'hi';
-            ctx.session.commitNow();
+            await ctx.session.commitNow();
             ctx.body = 200;
             return;
           }
@@ -396,7 +396,6 @@ describe('Koa Session External Context Store', () => {
 
         request(server)
         .post('/')
-        .expect('Set-Cookie', /koa:sess=.+;/)
         .expect('hi')
         .end(err => {
           if (err) return done(err);

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -385,18 +385,19 @@ describe('Koa Session External Context Store', () => {
         const app = App({ autoCommit: false });
         app.use(async function(ctx) {
           if (ctx.method === 'POST') {
-            ctx.session.message = 'hi';
+            ctx.session.message = 'dummy';
             ctx.body = 200;
-            await ctx.session.commitNow();
             return;
           }
-          ctx.body = ctx.session.message;
+        });
+        app.use(async function(ctx) {
+          await ctx.session.commitNow();
         });
         const server = app.listen();
 
         request(server)
         .post('/')
-        .expect('hi')
+        .expect('200')
         .end(err => {
           if (err) return done(err);
         })

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -358,7 +358,7 @@ describe('Koa Session External Context Store', () => {
 
   describe('when autoCommit is present', () => {
     describe('and set to false', () => {
-      it('should not set headers if commitNow() isn\'t called', done => {
+      it('should not set headers if manuallyCommit() isn\'t called', done => {
         const app = App({ autoCommit: false });
         app.use(async function(ctx) {
           if (ctx.method === 'POST') {
@@ -381,7 +381,7 @@ describe('Koa Session External Context Store', () => {
       });
     });
     describe('and set to false', () => {
-      it('should set headers if commitNow() is called', done => {
+      it('should set headers if manuallyCommit() is called', done => {
         const app = App({ autoCommit: false });
         app.use(async function(ctx) {
           if (ctx.method === 'POST') {

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -386,6 +386,7 @@ describe('Koa Session External Context Store', () => {
         app.use(async function(ctx) {
           if (ctx.method === 'POST') {
             ctx.session.message = 'hi';
+            ctx.session.commitNow()
             ctx.body = 200;
             return;
           }

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -356,27 +356,52 @@ describe('Koa Session External Context Store', () => {
     });
   });
 
-  describe('when autoCommit is present and set to false', () => {
-    it('should not set headers if commit() isn\'t called', done => {
-      const app = App({ autoCommit: false });
-      app.use(async function(ctx) {
-        if (ctx.method === 'POST') {
-          ctx.session.message = 'hi';
-          ctx.body = 200;
-          return;
-        }
-        ctx.body = ctx.session.message;
-      });
-      const server = app.listen();
+  describe('when autoCommit is present', () => {
+    describe('and set to false', () => {
+      it('should not set headers if commitNow() isn\'t called', done => {
+        const app = App({ autoCommit: false });
+        app.use(async function(ctx) {
+          if (ctx.method === 'POST') {
+            ctx.session.message = 'hi';
+            ctx.body = 200;
+            return;
+          }
+          ctx.body = ctx.session.message;
+        });
+        const server = app.listen();
 
-      request(server)
-      .post('/')
-      .end((err, res) => {
-        if (err) return done(err);
-        const cookie = res.headers['set-cookie'];
-        should.not.exists(cookie);
-      })
-      .expect(200, done);
+        request(server)
+        .post('/')
+        .end((err, res) => {
+          if (err) return done(err);
+          const cookie = res.headers['set-cookie'];
+          should.not.exists(cookie);
+        })
+        .expect(200, done);
+      });
+    });
+    describe('and set to false', () => {
+      it('should set headers if commitNow() is called', done => {
+        const app = App({ autoCommit: false });
+        app.use(async function(ctx) {
+          if (ctx.method === 'POST') {
+            ctx.session.message = 'hi';
+            ctx.body = 200;
+            return;
+          }
+          ctx.body = ctx.session.message;
+        });
+        const server = app.listen();
+
+        request(server)
+        .post('/')
+        .expect('Set-Cookie', /koa:sess=.+;/)
+        .expect('hi')
+        .end((err, res) => {
+          if (err) return done(err);
+        })
+        .expect(200, done);
+      });
     });
   });
 

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -386,7 +386,7 @@ describe('Koa Session External Context Store', () => {
         app.use(async function(ctx) {
           if (ctx.method === 'POST') {
             ctx.session.message = 'hi';
-            ctx.session.commitNow()
+            ctx.session.commitNow();
             ctx.body = 200;
             return;
           }


### PR DESCRIPTION
Currently, `koa-session` doesn't play well with [`nuxt`](https://github.com/nuxt/nuxt.js) because it tries to `commit()` headers after the Nuxt instance has finished the response object. This PR adds an `autoCommit` option, which can be set to `false` to allow users to manually `commit()` prior to the Nuxt middleware. I've been using a locally forked version for sometime with no issues.