### PR TITLE
Delete cookie on session destruction

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -272,7 +272,7 @@ class ContextSession {
     const externalKey = this.externalKey;
 
     if (externalKey) await this.store.destroy(externalKey);
-    ctx.cookies.set(key, '', opts);
+    ctx.cookies.set(key, '', {maxAge: -1});
   }
 
   /**


### PR DESCRIPTION
Right now when the session is destroyed, the session cookie is made empty, not removed.

That's an incorrect behavior, the cookie should be deleted as well. For that, we need to set the expiration date to the past, not just an empty value.