### PR TITLE
Use `turbo-crc32` package to calculate crc32.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const crc = require('crc').crc32;
+const crc = require('turbo-crc32/crc32');
 
 module.exports = {
 
@@ -32,6 +32,6 @@ module.exports = {
   },
 
   hash(sess) {
-    return crc(JSON.stringify(sess));
+    return crc(JSON.stringify(sess)) >> 0; // eslint-disable-line no-bitwise
   },
 };

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "crc": "^3.4.4",
     "debug": "^3.1.0",
     "is-type-of": "^1.0.0",
+    "turbo-crc32": "^1.0.1",
     "uid-safe": "^2.1.3"
   },
   "engines": {


### PR DESCRIPTION
`turbo-crc32` is about 2x times faster than `crc`.

```
crc:            987.866ms
buffer-crc32:   1387.205ms
turbo-crc32:    447.711ms
```