### PR TITLE
Renamed "should mock" tests

### DIFF
--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -700,7 +700,7 @@ describe('Koa Session External Context Store', () => {
   describe('ctx.session', () => {
     after(mm.restore);
 
-    it('should be mocked', done => {
+    it('can be mocked', done => {
       const app = App();
 
       app.use(async function(ctx) {

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -631,7 +631,7 @@ describe('Koa Session External Store', () => {
   describe('ctx.session', () => {
     after(mm.restore);
 
-    it('should be mocked', done => {
+    it('can be mocked', done => {
       const app = App();
 
       app.use(async function(ctx) {


### PR DESCRIPTION
As far as i can see these tests actually test if `mm` package works and don't test any of `koa-session` functionality. 