### PR TITLE
Set initial maxAge

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,8 @@ function formatOpts(opts) {
   // back-compat maxage
   if (!('maxAge' in opts)) opts.maxAge = opts.maxage;
 
+  opts.maxAge = opts.maxAge || 86400000;
+
   // defaults
   if (opts.overwrite == null) opts.overwrite = true;
   if (opts.httpOnly == null) opts.httpOnly = true;


### PR DESCRIPTION
The initial cookie that this middleware drops does not have `expires`, because `maxAge` is never set in properties. It is only set later when decoding the cookie, and only if it has been updated, therefore if no data was updated, the cookie is always limited to the session. 