### PR TITLE
#172: Correctly expire cookies for nullified sessions

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -4,6 +4,7 @@ const debug = require('debug')('koa-session:context');
 const Session = require('./session');
 const util = require('./util');
 
+const COOKIE_EXP_DATE = new Date(util.CookieDateEpoch);
 const ONE_DAY = 24 * 60 * 60 * 1000;
 
 class ContextSession {
@@ -273,7 +274,12 @@ class ContextSession {
    */
 
   async remove() {
-    const opts = this.opts;
+    // Override the default options so that we can properly expire the session cookies
+    const opts = Object.assign({}, this.opts, {
+      expires: COOKIE_EXP_DATE,
+      maxAge: false,
+    });
+
     const ctx = this.ctx;
     const key = opts.key;
     const externalKey = this.externalKey;

--- a/lib/util.js
+++ b/lib/util.js
@@ -34,4 +34,6 @@ module.exports = {
   hash(sess) {
     return crc(JSON.stringify(sess));
   },
+
+  CookieDateEpoch: 'Thu, 01 Jan 1970 00:00:00 GMT',
 };

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -249,6 +249,47 @@ describe('Koa Session Cookie', () => {
     });
   });
 
+  describe('after session set to null with signed cookie', () => {
+    it('should return expired cookies', done => {
+      const app = App({
+        signed: true,
+      });
+
+      app.use(async function(ctx) {
+        ctx.session.hello = {};
+        ctx.session = null;
+        ctx.body = String(ctx.session === null);
+      });
+
+      request(app.listen())
+        .get('/')
+        .expect('Set-Cookie', /koa:sess=; path=\/; expires=Thu, 01 Jan 1970 00:00:00 GMT/)
+        .expect('Set-Cookie', /koa:sess.sig=(.*); path=\/; expires=Thu, 01 Jan 1970 00:00:00 GMT/)
+        .expect('true')
+        .expect(200, done);
+    });
+  });
+
+  describe('after session set to null without signed cookie', () => {
+    it('should return expired cookies', done => {
+      const app = App({
+        signed: false,
+      });
+
+      app.use(async function(ctx) {
+        ctx.session.hello = {};
+        ctx.session = null;
+        ctx.body = String(ctx.session === null);
+      });
+
+      request(app.listen())
+        .get('/')
+        .expect('Set-Cookie', /koa:sess=; path=\/; expires=Thu, 01 Jan 1970 00:00:00 GMT/)
+        .expect('true')
+        .expect(200, done);
+    });
+  });
+
   describe('when get session after set to null', () => {
     it('should return null', done => {
       const app = App();


### PR DESCRIPTION
This references task #172.

When a session is set to null, any existing cookies should not only be set to null, but expired. The only way to correctly expire a cookie is by setting the _expires_ flag on the cookie to a date in the past.

I updated the cookie expire logic, since the cookies would just have the data set to null, which wouldn't remove the cookies from the users browser. 

By overriding the `maxAge` value to `false` and setting the `expires` to a date in the past, the cookies will be updated by the browser and removed. The expiry date is set as a non-exported file constant.

Signed cookies set by the module `cookie` will also be removed with this update.

Test case has been added to the test suite.