### PR TITLE
Security example for app.keys

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,10 +42,12 @@ $ npm install koa-session
 
 ```js
 const session = require('koa-session');
+const Keygrip = require('keygrip');
 const Koa = require('koa');
 const app = new Koa();
 
-app.keys = ['some secret hurr'];
+/** Redefining Keygrip to use sha512 */
+app.keys = new Keygrip(['insert 64 bytes random string', 'insert another 64 bytes random string'], 'sha512');
 
 const CONFIG = {
   key: 'koa:sess', /** (string) cookie key (default is koa:sess) */

--- a/example.js
+++ b/example.js
@@ -1,9 +1,10 @@
 
 var session = require('./');
 var Koa = require('koa');
+var Keygrip = require('keygrip');
 var app = new Koa();
 
-app.keys = ['some secret hurr'];
+app.keys = new Keygrip(['insert 64 bytes random string', 'insert another 64 bytes random string'], 'sha512');
 
 app.use(session(app));
 


### PR DESCRIPTION
**Documentation**:
  - Add a security example for `app.keys` by redefining Keygrip to use sha512 instead of default sha1