### PR TITLE
Add Secure Flag to Readme Example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -59,6 +59,7 @@ const CONFIG = {
   signed: true, /** (boolean) signed or not (default true) */
   rolling: false, /** (boolean) Force a session identifier cookie to be set on every response. The expiration is reset to the original maxAge, resetting the expiration countdown. (default is false) */
   renew: false, /** (boolean) renew session when session is nearly expired, so we can always keep user logged in. (default is false)*/
+  secure: true, /** (boolean) secure cookie*/
   sameSite: null, /** (string) session cookie sameSite options (default null, don't set it) */
 };
 


### PR DESCRIPTION
Makes sense to include the `secure` flag within the readme, as the whole config object is passed to Koa's ctx.cookies.set method. This will help prevent confusion and will solve #164 