### PR TITLE
Separate cookie maxAge option from external store ttl

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -299,7 +299,19 @@ class ContextSession {
     const externalKey = this.externalKey;
     let json = this.session.toJSON();
     // set expire for check
-    let maxAge = opts.maxAge ? opts.maxAge : ONE_DAY;
+    // maxAge refers to cookie value, while ttl refers to store value
+    const maxAge = opts.maxAge ? opts.maxAge : ONE_DAY;
+    // If ttl was not provided, take value from maxAge + 10s  to ensure
+    // store expires after cookie, unless maxAge is "session"
+    // then use default ONE_DAY
+    let ttl = opts.ttl;
+    if (!ttl) {
+      if (typeof maxAge === 'number') {
+        ttl = maxAge + 10000;
+      } else {
+        ttl = ONE_DAY;
+      }
+    }
     if (maxAge === 'session') {
       // do not set _expire in json if maxAge is set to 'session'
       // also delete maxAge from options
@@ -311,15 +323,18 @@ class ContextSession {
       json._maxAge = maxAge;
       if (!opts.maxAge) opts.maxAge = maxAge;
     }
+    if (ttl === 'permanent') {
+      // Unset ttl if permanent so external stores can conditionally
+      // store with ttl or not
+      ttl = undefined;
+    } else {
+      if (!opts.ttl) opts.ttl = ttl;
+    }
 
     // save to external store
     if (externalKey) {
       debug('save %j to external key %s', json, externalKey);
-      if (typeof maxAge === 'number') {
-        // ensure store expired after cookie
-        maxAge += 10000;
-      }
-      await this.store.set(externalKey, json, maxAge, {
+      await this.store.set(externalKey, json, ttl, {
         changed,
         rolling: opts.rolling,
       });

--- a/lib/context.js
+++ b/lib/context.js
@@ -309,6 +309,7 @@ class ContextSession {
       // set expire for check
       json._expire = maxAge + Date.now();
       json._maxAge = maxAge;
+      if (!opts.maxAge) opts.maxAge = maxAge;
     }
 
     // save to external store

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -713,8 +713,12 @@ describe('Koa Session Cookie', () => {
       request(app.listen())
       .get('/')
       .expect(res => {
-        const cookie = res.headers['set-cookie'].join('|');
-        assert(cookie.includes('path=/; samesite=none; httponly'));
+        const cookies = res.headers['set-cookie'];
+        cookies.length.should.equal(2);
+        for (const cookie of cookies) {
+          assert(cookie.includes('samesite=none; httponly'));
+          assert(cookie.includes('path=/;'));
+        }
       })
       .expect('bar')
       .expect(200, done);
@@ -731,8 +735,12 @@ describe('Koa Session Cookie', () => {
       request(app.listen())
       .get('/')
       .expect(res => {
-        const cookie = res.headers['set-cookie'].join('|');
-        assert(cookie.includes('path=/; samesite=lax; httponly'));
+        const cookies = res.headers['set-cookie'];
+        cookies.length.should.equal(2);
+        for (const cookie of cookies) {
+          assert(cookie.includes('samesite=lax; httponly'));
+          assert(cookie.includes('path=/;'));
+        }
       })
       .expect('bar')
       .expect(200, done);

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -805,6 +805,107 @@ describe('Koa Session External Store', () => {
         .expect({ foo: 'bar' });
     });
   });
+
+  describe('when ussing ttl', () => {
+    let app;
+    let currentStoreOpts;
+    let currentSessionOpts;
+    const ONE_DAY = 86400000;
+
+    const testMW = async ctx => {
+      ctx.session = { foo: 'bar' };
+      ctx.status = 204;
+      currentStoreOpts = ctx.session._sessCtx.externalKey;
+      currentSessionOpts = ctx.session._sessCtx.opts;
+    };
+
+    it('should use given ttl without affecting maxAge', async () => {
+      const originalTTL = 43200000;
+      app = App({ ttl: originalTTL });
+      app.use(testMW);
+      const res = await request(app.callback())
+        .get('/')
+        .expect({});
+
+      res.headers['set-cookie'].should.have.length(2);
+      const cookie = res.headers['set-cookie'].join(';');
+      cookie.should.containEql('expires=');
+      const storeKey = await store.get(currentStoreOpts);
+      storeKey._maxAge.should.equal(ONE_DAY);
+      currentSessionOpts.ttl.should.equal(originalTTL);
+      currentSessionOpts.maxAge.should.equal(ONE_DAY);
+    });
+
+    it('should use maxAge value if ttl is not provided', async () => {
+      const maxAge = 10000;
+      app = App({ maxAge });
+      app.use(testMW);
+      const res = await request(app.callback())
+        .get('/')
+        .expect({});
+
+      res.headers['set-cookie'].should.have.length(2);
+      const cookie = res.headers['set-cookie'].join(';');
+      cookie.should.containEql('expires=');
+      const storeKey = await store.get(currentStoreOpts);
+      storeKey._maxAge.should.equal(maxAge);
+      currentSessionOpts.ttl.should.equal(maxAge + 10000);
+      currentSessionOpts.maxAge.should.equal(maxAge);
+    });
+
+    it('should use default ONE_DAY if ttl is not provided and maxAge is session', async () => {
+      const maxAge = 'session';
+      app = App({ maxAge });
+      app.use(testMW);
+      const res = await request(app.callback())
+        .get('/')
+        .expect({});
+
+      res.headers['set-cookie'].should.have.length(2);
+      const cookie = res.headers['set-cookie'].join(';');
+      cookie.should.not.containEql('expires=');
+      const storeKey = await store.get(currentStoreOpts);
+      should.not.exist(storeKey._maxAge);
+      currentSessionOpts.ttl.should.equal(ONE_DAY);
+      should.not.exists(currentSessionOpts.maxAge);
+    });
+
+    it('should leave store ttl as undefined if ttl is permanent', async () => {
+      app = App({ ttl: 'permanent' });
+      app.use(testMW);
+      const res = await request(app.callback())
+        .get('/')
+        .expect({});
+
+      res.headers['set-cookie'].should.have.length(2);
+      const cookie = res.headers['set-cookie'].join(';');
+      cookie.should.containEql('expires=');
+      const storeKey = await store.get(currentStoreOpts);
+      storeKey._maxAge.should.equal(ONE_DAY);
+      currentSessionOpts.ttl.should.equal('permanent');
+      currentSessionOpts.maxAge.should.equal(ONE_DAY);
+    });
+
+    it('should allow changing ttl on request basis', async () => {
+      app = App({ ttl: 'permanent' });
+      app.use((ctx, next) => {
+        ctx.sessionOptions.ttl = 100000;
+        next();
+      });
+      app.use(testMW);
+      const res = await request(app.callback())
+        .get('/')
+        .expect({});
+
+      res.headers['set-cookie'].should.have.length(2);
+      const cookie = res.headers['set-cookie'].join(';');
+      cookie.should.containEql('expires=');
+      const storeKey = await store.get(currentStoreOpts);
+      storeKey._maxAge.should.equal(ONE_DAY);
+      currentSessionOpts.ttl.should.equal(100000);
+      currentSessionOpts.maxAge.should.equal(ONE_DAY);
+    });
+  });
 });
 
 function App(options) {


### PR DESCRIPTION
This PR allows to individually control cookie maxAge and external store TTL, for the cases where an unified control is not desired (like using with koa-redis).

Usage:
  - maxAge remains the same
  - ttl default is maxAge, unless maxAge is set to 'session' and ttl defaults to ONE_DAY
    allowed values for ttl are: 'permanent' (passes undefined ttl to external store) or any integer value

Previously using maxAge = 'session' with koa-redis would give an out of range error (since koa-redis is trying to insert word 'session' under ttl, with this implementation it will pass an integer value to ttl or if set as 'permanent', undefined and koa-redis will store without any ttl)