### PR TITLE
Bump dependencies (uuid, debug, dev-deps)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": "eslint-config-egg",
-  "parserOptions": {
-    "ecmaVersion": 2017
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-node_modules
-coverage
+node_modules/
+coverage/
+.nyc_output/
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - '7'
-  - '8'
-  - '10'
-  - '12'
-script: 'npm run test-travis'
-after_script: 'npm install coveralls@2 && cat ./coverage/lcov.info | coveralls'
+  - "node"
+  - "lts/*"
+after_success:
+  - c8 -r text-lcov npm test | coveralls
+

--- a/example.js
+++ b/example.js
@@ -7,11 +7,11 @@ app.keys = ['some secret hurr'];
 
 app.use(session(app));
 
-app.use(function* (next){
-  if ('/favicon.ico' == this.path) return;
-  var n = this.session.views || 0;
-  this.session.views = ++n;
-  this.body = n + ' views';
+app.use(function(ctx, next){
+  if ('/favicon.ico' == ctx.path) return;
+  var n = ctx.session.views || 0;
+  ctx.session.views = ++n;
+  ctx.body = n + ' views';
 });
 
 app.listen(3000);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const debug = require('debug')('koa-session');
 const ContextSession = require('./lib/context');
 const util = require('./lib/util');
 const assert = require('assert');
-const uuid = require('uuid/v4');
+const { v4: uuid } = require('uuid');
 const is = require('is-type-of');
 
 const CONTEXT_SESSION = Symbol('context#contextSession');
@@ -39,8 +39,6 @@ module.exports = function(opts, app) {
     if (sess.store) await sess.initFromExternal();
     try {
       await next();
-    } catch (err) {
-      throw err;
     } finally {
       if (opts.autoCommit) {
         await sess.commit();
@@ -122,7 +120,7 @@ function formatOpts(opts) {
  */
 
 function extendContext(context, opts) {
-  if (context.hasOwnProperty(CONTEXT_SESSION)) {
+  if (context.hasOwnProperty(CONTEXT_SESSION)) {  // eslint-disable-line no-prototype-builtins
     return;
   }
   Object.defineProperties(context, {

--- a/package.json
+++ b/package.json
@@ -15,32 +15,42 @@
   ],
   "devDependencies": {
     "benchmark": "^2.1.4",
-    "eslint": "3",
-    "eslint-config-egg": "3",
-    "istanbul": "0",
-    "koa": "2",
-    "mm": "^2.1.0",
-    "mocha": "^5.2.0",
+    "c8": "^7.0.0",
+    "coveralls": "^3.0.0",
+    "eslint": "^8.0.0",
+    "koa": "^2.0.0",
+    "mm": "^3.0.0",
+    "mocha": "^9.0.0",
     "mz-modules": "^2.0.0",
     "pedding": "^1.1.0",
     "uid-safe": "^2.1.3",
-    "should": "8",
-    "supertest": "^3.3.0"
+    "should": "^13.0.0",
+    "supertest": "^6.0.0"
   },
   "license": "MIT",
   "dependencies": {
     "crc": "^3.4.4",
-    "debug": "^3.1.0",
+    "debug": "^4.0.0",
     "is-type-of": "^1.0.0",
-    "uuid": "^3.3.2"
+    "uuid": "^8.0.0"
   },
   "engines": {
-    "node": ">=7.6"
+    "node": ">=10.0.0"
+  },
+  "eslintConfig": {
+    "env": {
+      "es6": true,
+      "node": true,
+      "mocha": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+      "ecmaVersion": 2017
+    }
   },
   "scripts": {
-    "test": "npm run lint && NODE_ENV=test mocha --exit --require should --reporter spec test/*.test.js",
-    "test-cov": "NODE_ENV=test node ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --exit --require should test/*.test.js",
-    "test-travis": "npm run lint && NODE_ENV=test node ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- --exit --require should test/*.test.js",
-    "lint": "eslint lib test index.js"
+    "test": "NODE_ENV=test mocha --exit test/*.test.js",
+    "cover": "c8 npm test",
+    "lint": "eslint lib/ test/ index.js"
   }
 }

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -380,7 +380,7 @@ describe('Koa Session External Context Store', () => {
 
   describe('when autoCommit is present', () => {
     describe('and set to false', () => {
-      it('should not set headers if manuallyCommit() isn\'t called', () => {
+      it('should not set headers if manuallyCommit() isn\'t called', done => {
         const app = App({ autoCommit: false });
         app.use(async function(ctx) {
           if (ctx.method === 'POST') {
@@ -398,6 +398,7 @@ describe('Koa Session External Context Store', () => {
         .end((err, res) => {
           const cookie = res.headers['set-cookie'];
           should.not.exist(cookie);
+          done();
         });
       });
       it('should set headers if manuallyCommit() is called', done => {

--- a/test/contextstore.test.js
+++ b/test/contextstore.test.js
@@ -380,7 +380,7 @@ describe('Koa Session External Context Store', () => {
 
   describe('when autoCommit is present', () => {
     describe('and set to false', () => {
-      it('should not set headers if manuallyCommit() isn\'t called', done => {
+      it('should not set headers if manuallyCommit() isn\'t called', () => {
         const app = App({ autoCommit: false });
         app.use(async function(ctx) {
           if (ctx.method === 'POST') {
@@ -394,12 +394,11 @@ describe('Koa Session External Context Store', () => {
 
         request(server)
         .post('/')
+        .expect(200)
         .end((err, res) => {
-          if (err) return done(err);
           const cookie = res.headers['set-cookie'];
           should.not.exist(cookie);
-        })
-        .expect(200, done);
+        });
       });
       it('should set headers if manuallyCommit() is called', done => {
         const app = App({ autoCommit: false });
@@ -418,9 +417,6 @@ describe('Koa Session External Context Store', () => {
         request(server)
         .post('/')
         .expect('Set-Cookie', /koa\.sess/)
-        .end(err => {
-          if (err) return done(err);
-        })
         .expect(200, done);
       });
     });

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -850,7 +850,7 @@ describe('Koa Session Cookie', () => {
     before(() => {
       app = App({ rolling: true });
 
-      app.use(function* () {
+      app.use(function* () { // eslint-disable-line require-yield
         console.log(this.path);
         if (this.path === '/set') this.session = { foo: 'bar' };
         this.body = this.session;


### PR DESCRIPTION
- tests: fix ".end() was called twice" in contextstore.test.js
- use eslint:recommended rather than Egg config
- eslint-disable no-prototype-builtins for hasOwnProperty(CONTEXT_SESSION) (?)
- eslint-disable require-yield in cookie.test.js (?)
- replace defunct istanbul with c8