### PR TITLE
feat: Add Session.regenerate() method (#34)

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -213,7 +213,7 @@ class ContextSession {
    * @api public
    */
 
-  async commit() {
+  async commit({ save = false, regenerate = false } = {}) {
     const session = this.session;
     const opts = this.opts;
     const ctx = this.ctx;
@@ -226,8 +226,13 @@ class ContextSession {
       await this.remove();
       return;
     }
+    if (regenerate) {
+      await this.remove();
+      if (this.store) this.externalKey = opts.genid && opts.genid(ctx);
+    }
 
-    const reason = this._shouldSaveSession();
+    // force save session when `session._requireSave` set
+    const reason = save || regenerate || session._requireSave ? 'force' : this._shouldSaveSession();
     debug('should save session: %s', reason);
     if (!reason) return;
 
@@ -242,9 +247,6 @@ class ContextSession {
   _shouldSaveSession() {
     const prevHash = this.prevHash;
     const session = this.session;
-
-    // force save session when `session._requireSave` set
-    if (session._requireSave) return 'force';
 
     // do nothing if new and not populated
     const json = session.toJSON();

--- a/lib/session.js
+++ b/lib/session.js
@@ -117,11 +117,23 @@ class Session {
   /**
    * save this session no matter whether it is populated
    *
+   * @param  {Function} callback the optional function to call after saving the session
    * @api public
    */
 
-  save() {
-    this._requireSave = true;
+  save(callback) {
+    return this.commit({ save: true }, callback);
+  }
+
+  /**
+   * regenerate this session
+   *
+   * @param  {Function} callback the optional function to call after regenerating the session
+   * @api public
+   */
+
+  regenerate(callback) {
+    return this.commit({ regenerate: true }, callback);
   }
 
   /**
@@ -130,10 +142,22 @@ class Session {
    * @api public
    */
 
-  async manuallyCommit() {
-    await this._sessCtx.commit();
+  manuallyCommit() {
+    return this.commit();
   }
 
+  commit(options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+    const promise = this._sessCtx.commit(options);
+    if (callback) {
+      promise.then(() => callback(), callback);
+    } else {
+      return promise;
+    }
+  }
 }
 
 module.exports = Session;

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -674,6 +674,48 @@ describe('Koa Session Cookie', () => {
     });
   });
 
+  describe('ctx.session.regenerate', () => {
+    it('should change the session key, but not content', done => {
+      const app = new App();
+      const message = 'hi';
+      app.use(async function(ctx, next) {
+        ctx.session = { message: 'hi' };
+        await next();
+      });
+
+      app.use(async function(ctx, next) {
+        const sessionKey = ctx.cookies.get('koa.sess');
+        if (sessionKey) {
+          await ctx.session.regenerate();
+        }
+        await next();
+      });
+
+      app.use(async function(ctx) {
+        ctx.session.message.should.equal(message);
+        ctx.body = '';
+      });
+      let koaSession = null;
+      request(app.callback())
+      .get('/')
+      .expect(200, (err, res) => {
+        should.not.exist(err);
+        koaSession = res.headers['set-cookie'][0];
+        koaSession.should.containEql('koa.sess=');
+        request(app.callback())
+        .get('/')
+        .set('Cookie', koaSession)
+        .expect(200, (err, res) => {
+          should.not.exist(err);
+          const cookies = res.headers['set-cookie'][0];
+          cookies.should.containEql('koa.sess=');
+          cookies.should.not.equal(koaSession);
+          done();
+        });
+      });
+    });
+  });
+
   describe('when get session before enter session middleware', () => {
     it('should work', done => {
       const app = new Koa();


### PR DESCRIPTION
And make both `save()` and `regenerate()` compatible with `koa-passport` v5.0.0

This is based on #74 which is a bit outdated, and more work was needed to make this work with `koa-passport` due to the use of `callback` arguments.

See https://github.com/rkusa/koa-passport/issues/181 for more details.