### PR TITLE
Support setting cookie domain on a per-request basis.

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -128,7 +128,7 @@ class ContextSession {
       debug('decode %j error: %s', cookie, err);
       if (!(err instanceof SyntaxError)) {
         // clean this cookie to ensure next request won't throw again
-        ctx.cookies.set(opts.key, '', opts);
+        ctx.cookies.set(opts.key, '', util.modifyOptsForRequest(ctx, opts));
         // ctx.onerror will unset all headers, and set those specified in err
         err.headers = {
           'set-cookie': ctx.response.get('set-cookie'),
@@ -287,7 +287,7 @@ class ContextSession {
     const externalKey = this.externalKey;
 
     if (externalKey) await this.store.destroy(externalKey, { ctx });
-    ctx.cookies.set(key, '', opts);
+    ctx.cookies.set(key, '', util.modifyOptsForRequest(ctx, opts));
   }
 
   /**
@@ -328,7 +328,7 @@ class ContextSession {
       if (opts.externalKey) {
         opts.externalKey.set(this.ctx, externalKey);
       } else {
-        this.ctx.cookies.set(key, externalKey, opts);
+        this.ctx.cookies.set(key, externalKey, util.modifyOptsForRequest(this.ctx, opts));
       }
       return;
     }
@@ -338,7 +338,7 @@ class ContextSession {
     json = opts.encode(json);
     debug('save %s', json);
 
-    this.ctx.cookies.set(key, json, opts);
+    this.ctx.cookies.set(key, json, util.modifyOptsForRequest(this.ctx, opts));
   }
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -37,7 +37,7 @@ module.exports = {
 
   modifyOptsForRequest(ctx, opts) {
     const optsCopy = Object.assign({}, opts);
-    if (typeof opts.domain === "function") {
+    if (typeof opts.domain === 'function') {
       optsCopy.domain = opts.domain(ctx, opts);
     }
     return optsCopy;

--- a/lib/util.js
+++ b/lib/util.js
@@ -35,5 +35,13 @@ module.exports = {
     return crc(JSON.stringify(sess));
   },
 
+  modifyOptsForRequest(ctx, opts) {
+    const optsCopy = Object.assign({}, opts);
+    if (typeof opts.domain === "function") {
+      optsCopy.domain = opts.domain(ctx, opts);
+    }
+    return optsCopy;
+  },
+
   CookieDateEpoch: 'Thu, 01 Jan 1970 00:00:00 GMT',
 };


### PR DESCRIPTION
This is a proof-of-concept to enable passing a function for the `domain` config option to dynamically modify the cookie domain based on the incoming request.

It does so by adding a call to a new `modifyOptsForRequest` helper anywhere `cookies.set` is called. 

`modifyOptsForRequest` creates a copy of `opts`, checks whether the `opts.domain` value is a function, and replaces the `domain` value with the result of that function if so.

An example of how this might be used:

```js
app.use(session({
  domain: (ctx, opts) => {
    return ctx.get("origin") || DEFAULT_ORIGIN;
  }
});
```

This specifically addresses https://github.com/koajs/session/issues/188, but it should be easy to extend this PR to support the other cookie config options (like `httpOnly`, `maxAge`, etc.). If this approach looks good and maintainers would be interested in the fix, I'd be happy to update this PR to properly do so - let me know!