### PR TITLE
Add support for dynamicly setting the cookie domain based on request.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,11 @@ export const SessionOptions = z.object({
     .args(z.any(), z.any())
     .returns(z.void())
     .optional(),
+  /**
+   * Restrict the cookie domain with either a static string or a function that
+   * return a string.
+   */
+  domain: z.union([ z.string(), z.function().args(z.any(), z.any()).returns(z.string()) ]).optional(),
 });
 
 const DEFAULT_SESSION_OPTIONS = SessionOptions.parse({});

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,3 +24,4 @@ export default {
 
   CookieDateEpoch: 'Thu, 01 Jan 1970 00:00:00 GMT',
 };
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,6 @@
     "noImplicitAny": true,
     "target": "ES2022",
     "module": "NodeNext",
-    "moduleResolution": "NodeNext"
+    "moduleResolution": "NodeNext",
   }
 }


### PR DESCRIPTION
Rebased off the latest version of the upstream (7.0.2)

This is a proof-of-concept to enable passing a function for the domain config option to dynamically modify the cookie domain based on the incoming request.

It does so by adding a call to a new modifyOptsForRequest helper anywhere cookies.set is called.

modifyOptsForRequest creates a copy of opts, checks whether the opts.domain value is a function, and replaces the domain value with the result of that function if so.

An example of how this might be used:

app.use(session({
  domain: (ctx, opts) => {
    return ctx.get("origin") || DEFAULT_ORIGIN;
  }
});
This specifically addresses https://github.com/koajs/session/issues/188, but it should be easy to extend this PR to support the other cookie config options (like httpOnly, maxAge, etc.). If this approach looks good and maintainers would be interested in the fix, I'd be happy to update this PR to properly do so - let me know!

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
